### PR TITLE
Fix PriceSync service and schema

### DIFF
--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -12,7 +12,7 @@ class InstallSchema implements InstallSchemaInterface
         $installer = $setup;
         $installer->startSetup();
         $table = $installer->getConnection()->newTable(
-            $installer->getTable('accord_customer_price')
+            $installer->getTable('tr_customer_pricing')
         )
         ->addColumn('entity_id', \Magento\Framework\Db\Ddl\Table::TYPE_INTEGER, null, [
             'identity' => true, 'nullable' => false, 'primary' => true
@@ -23,7 +23,7 @@ class InstallSchema implements InstallSchemaInterface
         ->addColumn('created_at', \Magento\Framework\Db\Ddl\Table::TYPE_TIMESTAMP, null, ['nullable' => false, 'default' => \Magento\Framework\Db\Ddl\Table::TIMESTAMP_INIT], 'Created At')
         ->addColumn('updated_at', \Magento\Framework\Db\Ddl\Table::TYPE_TIMESTAMP, null, ['nullable' => false, 'default' => \Magento\Framework\Db\Ddl\Table::TIMESTAMP_INIT_UPDATE], 'Updated At')
         ->addIndex(
-            $installer->getIdxName('accord_customer_price', ['customer_code', 'sku'], \Magento\Framework\Db\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE),
+            $installer->getIdxName('tr_customer_pricing', ['customer_code', 'sku'], \Magento\Framework\Db\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE),
             ['customer_code', 'sku'], ['type' => \Magento\Framework\Db\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE]
         );
         $installer->getConnection()->createTable($table);


### PR DESCRIPTION
## Summary
- fix price sync service: use correct repository method and factory
- fix install schema table name

## Testing
- `php -l Service/PriceSync.php`
- `php -l Setup/InstallSchema.php`
- `for f in $(find . -name '*.php'); do php -l $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_68686c3c663483278427f62186e6d10a