### PR TITLE
Fix price retrieval check and add test

### DIFF
--- a/Model/PriceRepository.php
+++ b/Model/PriceRepository.php
@@ -87,8 +87,8 @@ class PriceRepository implements PriceRepositoryInterface
         $collection->addFieldToFilter('accord_customer_code', $customerCode)
                    ->addFieldToFilter('sku', $sku);
 
-        if ($collection->getSize() > 0) {
-            $priceModel = $collection->getFirstItem();
+        $priceModel = $collection->getFirstItem();
+        if ($priceModel && $priceModel->getId()) {
 
             // Save the found price data to cache for next time
             $this->cache->save(

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="CustomerPricing Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Model/PriceRepositoryTest.php
+++ b/tests/Model/PriceRepositoryTest.php
@@ -1,0 +1,43 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use TR\CustomerPricing\Model\PriceRepository;
+use TR\CustomerPricing\Model\ResourceModel\Price as PriceResource;
+use TR\CustomerPricing\Model\PriceFactory;
+use TR\CustomerPricing\Model\ResourceModel\Price\CollectionFactory;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use TR\CustomerPricing\Model\ResourceModel\Price\DummyCollection;
+use TR\CustomerPricing\Model\Price;
+
+class PriceRepositoryTest extends TestCase
+{
+    public function testGetPriceByCodeAndSkuReturnsNullWhenPriceMissing()
+    {
+        $resource = $this->createStub(PriceResource::class);
+        $priceFactory = $this->createStub(PriceFactory::class);
+
+        $emptyPrice = $this->createStub(Price::class);
+        $emptyPrice->method('getId')->willReturn(null);
+
+        $collection = new DummyCollection($emptyPrice);
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->expects($this->once())
+                          ->method('create')
+                          ->willReturn($collection);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+              ->method('load')
+              ->willReturn(false);
+        $cache->expects($this->never())
+              ->method('save');
+
+        $serializer = $this->createStub(SerializerInterface::class);
+
+        $repo = new PriceRepository($resource, $priceFactory, $collectionFactory, $cache, $serializer);
+        $result = $repo->getPriceByCodeAndSku('CODE', 'SKU');
+        $this->assertNull($result);
+    }
+}
+?>

--- a/tests/Stubs/Magento/Framework/App/CacheInterface.php
+++ b/tests/Stubs/Magento/Framework/App/CacheInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace Magento\Framework\App;
+interface CacheInterface {
+    public function load($id);
+    public function save($data, $id, array $tags = [], $lifeTime = null);
+    public function remove($id);
+}
+?>

--- a/tests/Stubs/Magento/Framework/Exception/CouldNotDeleteException.php
+++ b/tests/Stubs/Magento/Framework/Exception/CouldNotDeleteException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Magento\Framework\Exception;
+class CouldNotDeleteException extends \Exception {}
+?>

--- a/tests/Stubs/Magento/Framework/Exception/CouldNotSaveException.php
+++ b/tests/Stubs/Magento/Framework/Exception/CouldNotSaveException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Magento\Framework\Exception;
+class CouldNotSaveException extends \Exception {}
+?>

--- a/tests/Stubs/Magento/Framework/Exception/NoSuchEntityException.php
+++ b/tests/Stubs/Magento/Framework/Exception/NoSuchEntityException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Magento\Framework\Exception;
+class NoSuchEntityException extends \Exception {}
+?>

--- a/tests/Stubs/Magento/Framework/Model/AbstractModel.php
+++ b/tests/Stubs/Magento/Framework/Model/AbstractModel.php
@@ -1,0 +1,14 @@
+<?php
+namespace Magento\Framework\Model;
+abstract class AbstractModel implements \ArrayAccess {
+    protected function _init($model){ }
+    public function getId(){ return $this->getData('entity_id'); }
+    public function setId($id){ return $this->setData('entity_id', $id); }
+    public function offsetExists($offset){return isset($this->$offset);}
+    public function offsetGet($offset){return $this->$offset;}
+    public function offsetSet($offset,$value){$this->$offset=$value;}
+    public function offsetUnset($offset){unset($this->$offset);}
+    public function getData($key = ''){return $this->$key ?? null;}
+    public function setData($key,$value){$this->$key=$value; return $this;}
+}
+?>

--- a/tests/Stubs/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
+++ b/tests/Stubs/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
@@ -1,0 +1,4 @@
+<?php
+namespace Magento\Framework\Model\ResourceModel\Db;
+abstract class AbstractDb {}
+?>

--- a/tests/Stubs/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
+++ b/tests/Stubs/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
@@ -1,0 +1,4 @@
+<?php
+namespace Magento\Framework\Model\ResourceModel\Db\Collection;
+abstract class AbstractCollection {}
+?>

--- a/tests/Stubs/Magento/Framework/Serialize/SerializerInterface.php
+++ b/tests/Stubs/Magento/Framework/Serialize/SerializerInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace Magento\Framework\Serialize;
+interface SerializerInterface {
+    public function serialize($data);
+    public function unserialize($string);
+}
+?>

--- a/tests/Stubs/TR/CustomerPricing/Model/PriceFactory.php
+++ b/tests/Stubs/TR/CustomerPricing/Model/PriceFactory.php
@@ -1,0 +1,8 @@
+<?php
+namespace TR\CustomerPricing\Model;
+class PriceFactory {
+    public function create(array $data = []) {
+        return new Price($data);
+    }
+}
+?>

--- a/tests/Stubs/TR/CustomerPricing/Model/ResourceModel/Price/CollectionFactory.php
+++ b/tests/Stubs/TR/CustomerPricing/Model/ResourceModel/Price/CollectionFactory.php
@@ -1,0 +1,8 @@
+<?php
+namespace TR\CustomerPricing\Model\ResourceModel\Price;
+class CollectionFactory {
+    public function create() {
+        return new Collection();
+    }
+}
+?>

--- a/tests/Stubs/TR/CustomerPricing/Model/ResourceModel/Price/DummyCollection.php
+++ b/tests/Stubs/TR/CustomerPricing/Model/ResourceModel/Price/DummyCollection.php
@@ -1,0 +1,9 @@
+<?php
+namespace TR\CustomerPricing\Model\ResourceModel\Price;
+class DummyCollection extends Collection {
+    private $item;
+    public function __construct($item) { $this->item = $item; }
+    public function addFieldToFilter($field, $value) { return $this; }
+    public function getFirstItem() { return $this->item; }
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+spl_autoload_register(function ($class) {
+    $prefixes = [
+        'TR\\CustomerPricing\\' => [__DIR__ . '/../', __DIR__ . '/Stubs/TR/CustomerPricing/'],
+        'Magento\\Framework\\' => [__DIR__ . '/Stubs/Magento/Framework/'],
+    ];
+    foreach ($prefixes as $prefix => $baseDir) {
+        $len = strlen($prefix);
+        if (strncmp($class, $prefix, $len) !== 0) {
+            continue;
+        }
+        $relativeClass = substr($class, $len);
+        foreach ((array)$baseDir as $dir) {
+            $file = $dir . str_replace('\\', '/', $relativeClass) . '.php';
+            if (file_exists($file)) {
+                require_once $file;
+                return;
+            }
+        }
+    }
+});
+?>


### PR DESCRIPTION
## Summary
- avoid using `getSize()` by checking the first item
- add PHPUnit configuration and bootstrap autoloader
- stub framework classes so unit tests can run without Magento
- add a unit test for missing price lookup

## Testing
- `phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6868da7e725483279fa96fbc07d94c31