### PR TITLE
Support bulk price fetching

### DIFF
--- a/Api/PriceRepositoryInterface.php
+++ b/Api/PriceRepositoryInterface.php
@@ -8,6 +8,7 @@ interface PriceRepositoryInterface
     public function save(PriceInterface $price);
     public function getById($id);
     public function getPriceByCodeAndSku($customerCode, $sku);
+    public function getPricesByCodeAndSkus($customerCode, array $skus);
     public function delete(PriceInterface $price);
     public function deleteById($id);
 }

--- a/Controller/Price/Get.php
+++ b/Controller/Price/Get.php
@@ -42,8 +42,8 @@ class Get implements HttpGetActionInterface
             if ($customerCodeAttr && $customerCodeAttr->getValue()) {
                 $customerCode = $customerCodeAttr->getValue();
                 
-                foreach ($skus as $sku) {
-                    $customPrice = $this->priceRepository->getPriceByCodeAndSku($customerCode, $sku);
+                $prices = $this->priceRepository->getPricesByCodeAndSkus($customerCode, $skus);
+                foreach ($prices as $sku => $customPrice) {
                     if ($customPrice && $customPrice->getId()) {
                         $price = (float)$customPrice->getPrice();
                         $priceData[$sku] = [

--- a/Model/PriceRepository.php
+++ b/Model/PriceRepository.php
@@ -103,6 +103,44 @@ class PriceRepository implements PriceRepositoryInterface
         return null;
     }
 
+    public function getPricesByCodeAndSkus($customerCode, array $skus)
+    {
+        $results = [];
+        $skusToQuery = [];
+
+        foreach ($skus as $sku) {
+            $cacheKey = self::CACHE_TAG . '_' . $customerCode . '_' . $sku;
+            $cachedData = $this->cache->load($cacheKey);
+            if ($cachedData) {
+                $data = $this->serializer->unserialize($cachedData);
+                $results[$sku] = $this->priceFactory->create(['data' => $data]);
+            } else {
+                $skusToQuery[] = $sku;
+            }
+        }
+
+        if (!empty($skusToQuery)) {
+            $collection = $this->priceCollectionFactory->create();
+            $collection->addFieldToFilter('accord_customer_code', $customerCode)
+                       ->addFieldToFilter('sku', ['in' => $skusToQuery]);
+
+            foreach ($collection as $priceModel) {
+                $sku = $priceModel->getSku();
+                $results[$sku] = $priceModel;
+
+                $cacheKey = self::CACHE_TAG . '_' . $customerCode . '_' . $sku;
+                $this->cache->save(
+                    $this->serializer->serialize($priceModel->getData()),
+                    $cacheKey,
+                    [self::CACHE_TAG],
+                    self::CACHE_LIFETIME
+                );
+            }
+        }
+
+        return $results;
+    }
+
     public function delete(PriceInterface $price)
     {
         try {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="CustomerPricing Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/PriceRepositoryTest.php
+++ b/tests/PriceRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Tests\Stubs\Cache;
+use Tests\Stubs\Serializer;
+use TR\CustomerPricing\Model\PriceFactory;
+use TR\CustomerPricing\Model\ResourceModel\Price\CollectionFactory;
+use TR\CustomerPricing\Model\ResourceModel\Price as PriceResource;
+use TR\CustomerPricing\Model\PriceRepository;
+
+class PriceRepositoryTest extends TestCase
+{
+    public function testGetPricesByCodeAndSkusReturnsDataForMultipleSkus()
+    {
+        $items = [
+            [\TR\CustomerPricing\Api\Data\PriceInterface::ACCORD_CUSTOMER_CODE => 'C001', \TR\CustomerPricing\Api\Data\PriceInterface::SKU => 'sku1', \TR\CustomerPricing\Api\Data\PriceInterface::PRICE => 10, \TR\CustomerPricing\Api\Data\PriceInterface::ENTITY_ID => 1],
+            [\TR\CustomerPricing\Api\Data\PriceInterface::ACCORD_CUSTOMER_CODE => 'C001', \TR\CustomerPricing\Api\Data\PriceInterface::SKU => 'sku2', \TR\CustomerPricing\Api\Data\PriceInterface::PRICE => 20, \TR\CustomerPricing\Api\Data\PriceInterface::ENTITY_ID => 2],
+            [\TR\CustomerPricing\Api\Data\PriceInterface::ACCORD_CUSTOMER_CODE => 'C002', \TR\CustomerPricing\Api\Data\PriceInterface::SKU => 'sku3', \TR\CustomerPricing\Api\Data\PriceInterface::PRICE => 30, \TR\CustomerPricing\Api\Data\PriceInterface::ENTITY_ID => 3],
+        ];
+
+        $repo = new PriceRepository(
+            new PriceResource(),
+            new PriceFactory(),
+            new \TR\CustomerPricing\Model\ResourceModel\Price\CollectionFactory($items),
+            new Cache(),
+            new Serializer()
+        );
+
+        $prices = $repo->getPricesByCodeAndSkus('C001', ['sku1','sku2']);
+
+        $this->assertCount(2, $prices);
+        $this->assertEquals(10, $prices['sku1']->getPrice());
+        $this->assertEquals(20, $prices['sku2']->getPrice());
+    }
+}

--- a/tests/Stubs.php
+++ b/tests/Stubs.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Magento\Framework\Serialize;
+interface SerializerInterface {
+    public function serialize($data);
+    public function unserialize($string);
+}
+
+namespace Magento\Framework\App;
+interface CacheInterface {
+    public function load($id);
+    public function save($data, $id, $tags = [], $lifetime = null);
+    public function remove($id);
+    public function clean($tags = []);
+}
+
+namespace TR\CustomerPricing\Model\ResourceModel;
+class Price {}
+
+namespace Tests\Stubs;
+
+use TR\CustomerPricing\Api\Data\PriceInterface;
+
+class Serializer implements \Magento\Framework\Serialize\SerializerInterface {
+    public function serialize($data) { return json_encode($data); }
+    public function unserialize($string) { return json_decode($string, true); }
+}
+
+class Cache implements \Magento\Framework\App\CacheInterface {
+    private $data = [];
+    public function load($id) { return $this->data[$id] ?? false; }
+    public function save($data, $id, $tags = [], $lifetime = null) { $this->data[$id] = $data; return true; }
+    public function remove($id) { unset($this->data[$id]); return true; }
+    public function clean($tags = []) { return true; }
+}
+
+class Price implements PriceInterface {
+    private $data = [];
+    public function __construct(array $data = []) { $this->data = $data; }
+    public function getId() { return $this->data[self::ENTITY_ID] ?? null; }
+    public function getAccordCustomerCode() { return $this->data[self::ACCORD_CUSTOMER_CODE] ?? null; }
+    public function setAccordCustomerCode($code) { $this->data[self::ACCORD_CUSTOMER_CODE] = $code; return $this; }
+    public function getSku() { return $this->data[self::SKU] ?? null; }
+    public function setSku($sku) { $this->data[self::SKU] = $sku; return $this; }
+    public function getPrice() { return $this->data[self::PRICE] ?? null; }
+    public function setPrice($price) { $this->data[self::PRICE] = $price; return $this; }
+    public function getData() { return $this->data; }
+}
+
+class PriceCollection implements \IteratorAggregate {
+    private $items; private $customerCode; private $skuCond;
+    public function __construct(array $items) { $this->items = $items; }
+    public function addFieldToFilter($field, $condition) {
+        if ($field === 'accord_customer_code') { $this->customerCode = $condition; }
+        elseif ($field === 'sku') { $this->skuCond = $condition; }
+        return $this;
+    }
+    public function getIterator() {
+        $filtered = [];
+        foreach ($this->items as $item) {
+            if ($this->customerCode !== null && $item[PriceInterface::ACCORD_CUSTOMER_CODE] !== $this->customerCode) continue;
+            if ($this->skuCond !== null) {
+                if (is_array($this->skuCond)) {
+                    if (isset($this->skuCond['in']) && !in_array($item[PriceInterface::SKU], $this->skuCond['in'])) continue;
+                    if (!isset($this->skuCond['in']) && $item[PriceInterface::SKU] !== $this->skuCond) continue;
+                } elseif ($item[PriceInterface::SKU] !== $this->skuCond) continue;
+            }
+            $filtered[] = new Price($item);
+        }
+        return new \ArrayIterator($filtered);
+    }
+}
+
+namespace TR\CustomerPricing\Model;
+class PriceFactory {
+    public function create(array $data = []) { if(isset($data['data'])) $data = $data['data']; return new \Tests\Stubs\Price($data); }
+}
+
+namespace TR\CustomerPricing\Model\ResourceModel\Price;
+class CollectionFactory {
+    private $items;
+    public function __construct(array $items) { $this->items = $items; }
+    public function create() { return new \Tests\Stubs\PriceCollection($this->items); }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/../Api/Data/PriceInterface.php';
+require_once __DIR__ . '/../Api/PriceRepositoryInterface.php';
+require_once __DIR__ . '/../Model/PriceRepository.php';
+require_once __DIR__ . '/Stubs.php';


### PR DESCRIPTION
## Summary
- add `getPricesByCodeAndSkus` to the repository interface
- implement bulk price lookup with caching
- refactor price controller to use the bulk call
- introduce PHPUnit tests for multi-SKU retrieval

## Testing
- `phpunit --configuration phpunit.xml --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6868dab1cb0083279d1db299d52001ec